### PR TITLE
Notify multiple channels

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -4,12 +4,14 @@ account:
 scrapekot:
   slack: 
     webhook_url: 
-    channel: 
+    channels:
+      -
     icon_emoji: 
     username: 
 myrecorder: 
   slack:  
     webhook_url: 
-    channel: 
+    channels:
+      -
     icon_emoji: 
     username: 

--- a/kot/common/config.py
+++ b/kot/common/config.py
@@ -16,7 +16,7 @@ class Account:
 @dataclass
 class Slack:
     webhook_url: str
-    channel: str
+    channels: list[str]
     icon_emoji: str
     username: str
 
@@ -40,13 +40,16 @@ class Config:
     scrapekot:
         slack:
             webhook_url: url
-            channel: channel
+            channels:
+              - channel_a
             icon_emoji: icon
             username: username
     myrecorder:
         slack:
             webhook_url: url
-            channel: channel
+            channels:
+              - channel_a
+              - channel_b
             icon_emoji: icon
             username: username
     """
@@ -79,7 +82,7 @@ def generate_config(d: dict[str, Any]) -> Config:
         scrapekot=ScrapeKOT(
             slack=Slack(
                 webhook_url=d["scrapekot"]["slack"].get("webhook_url", ""),
-                channel=d["scrapekot"]["slack"].get("channel", ""),
+                channels=d["scrapekot"]["slack"].get("channels", [""]),
                 icon_emoji=d["scrapekot"]["slack"].get("icon_emoji", ""),
                 username=d["scrapekot"]["slack"].get("username", ""),
             ),
@@ -87,7 +90,7 @@ def generate_config(d: dict[str, Any]) -> Config:
         myrecorder=MyRecorder(
             slack=Slack(
                 webhook_url=d["myrecorder"]["slack"].get("webhook_url", ""),
-                channel=d["myrecorder"]["slack"].get("channel", ""),
+                channels=d["myrecorder"]["slack"].get("channels", [""]),
                 icon_emoji=d["myrecorder"]["slack"].get("icon_emoji", ""),
                 username=d["myrecorder"]["slack"].get("username", ""),
             ),
@@ -104,7 +107,7 @@ def read_lambda_env() -> dict[str, Any]:
         "myrecorder": {
             "slack": {
                 "webhook_url": os.environ["MYRECORDER_SLACK_WEBHOOK_URL"],
-                "channel": os.environ["MYRECORDER_SLACK_CHANNEL"],
+                "channels": [os.environ["MYRECORDER_SLACK_CHANNEL"]],
                 "icon_emoji": os.environ["MYRECORDER_SLACK_ICON_EMOJI"],
                 "username": os.environ["MYRECORDER_SLACK_USERNAME"],
             }
@@ -112,7 +115,7 @@ def read_lambda_env() -> dict[str, Any]:
         "scrapekot": {
             "slack": {
                 "webhook_url": os.environ["SCRAPEKOT_SLACK_WEBHOOK_URL"],
-                "channel": os.environ["SCRAPEKOT_SLACK_CHANNEL"],
+                "channels": [os.environ["SCRAPEKOT_SLACK_CHANNEL"]],
                 "icon_emoji": os.environ["SCRAPEKOT_SLACK_ICON_EMOJI"],
                 "username": os.environ["SCRAPEKOT_SLACK_USERNAME"],
             }

--- a/kot/common/notify.py
+++ b/kot/common/notify.py
@@ -8,7 +8,7 @@ import requests
 @dataclass
 class NotifyData:
     slack_webhook_url: str
-    slack_channel: str
+    slack_channels: list[str]
     slack_icon_emoji: str
     slack_username: str
     message: str
@@ -29,11 +29,12 @@ class BaseSlackClient:
 
     def _post_slack(self, notify_data: NotifyData) -> None:
         url = self._slack_url(notify_data)
-        data = json.dumps(self._slack_data(notify_data))
-        requests.post(url, data)
+        data = self._slack_data(notify_data)
+        for d in data:
+            requests.post(url, json.dumps(d))
 
     def _slack_url(self, notify_data: NotifyData) -> str:
         raise NotImplementedError
 
-    def _slack_data(self, notify_data: NotifyData) -> dict[str, Any]:
+    def _slack_data(self, notify_data: NotifyData) -> list[dict[str, Any]]:
         raise NotImplementedError

--- a/kot/myrecorder/notify.py
+++ b/kot/myrecorder/notify.py
@@ -10,7 +10,7 @@ from kot.myrecorder import MyRecorderOptions
 @dataclass
 class SlackClientParams:
     slack_webhook_url: str
-    slack_channel: str
+    slack_channels: list[str]
     slack_icon_emoji: str
     slack_username: str
     command: str
@@ -35,7 +35,7 @@ class SlackClient(BaseSlackClient):
             return None
         return NotifyData(
             slack_webhook_url=params.slack_webhook_url,
-            slack_channel=params.slack_channel,
+            slack_channels=params.slack_channels,
             slack_icon_emoji=params.slack_icon_emoji,
             slack_username=params.slack_username,
             message=kintai_message,
@@ -44,10 +44,15 @@ class SlackClient(BaseSlackClient):
     def _slack_url(self, notify_data: NotifyData) -> str:
         return notify_data.slack_webhook_url
 
-    def _slack_data(self, notify_data: NotifyData) -> dict:
-        return {
-            "username": notify_data.slack_username,
-            "icon_emoji": notify_data.slack_icon_emoji,
-            "channel": notify_data.slack_channel,
-            "text": notify_data.message,
-        }
+    def _slack_data(self, notify_data: NotifyData) -> list[dict[str, Any]]:
+        data = []
+        for slack_channel in notify_data.slack_channels:
+            data.append(
+                {
+                    "username": notify_data.slack_username,
+                    "icon_emoji": notify_data.slack_icon_emoji,
+                    "channel": slack_channel,
+                    "text": notify_data.message,
+                }
+            )
+        return data

--- a/kot/scrapekot/notify.py
+++ b/kot/scrapekot/notify.py
@@ -12,7 +12,7 @@ from kot.scrapekot.aggregate import AggregatedData
 @dataclass
 class SlackClientParams:
     slack_webhook_url: str
-    slack_channel: str
+    slack_channels: list[str]
     slack_icon_emoji: str
     slack_username: str
     dt_now: datetime
@@ -31,7 +31,7 @@ class SlackClient(BaseSlackClient):
         color = self._get_color(data.saving_time)
         return NotifyData(
             slack_webhook_url=params.slack_webhook_url,
-            slack_channel=params.slack_channel,
+            slack_channels=params.slack_channels,
             slack_icon_emoji=params.slack_icon_emoji,
             slack_username=params.slack_username,
             message=message,
@@ -63,19 +63,24 @@ class SlackClient(BaseSlackClient):
     def _slack_url(self, notify_data: NotifyData) -> str:
         return notify_data.slack_webhook_url
 
-    def _slack_data(self, notify_data: NotifyData) -> dict[str, Any]:
-        return {
-            "username": notify_data.slack_username,
-            "icon_emoji": notify_data.slack_icon_emoji,
-            "channel": notify_data.slack_channel,
-            "attachments": [
+    def _slack_data(self, notify_data: NotifyData) -> list[dict[str, Any]]:
+        data = []
+        for slack_channel in notify_data.slack_channels:
+            data.append(
                 {
-                    "pretext": notify_data.title,
-                    "color": notify_data.color,
-                    "text": notify_data.message,
+                    "username": notify_data.slack_username,
+                    "icon_emoji": notify_data.slack_icon_emoji,
+                    "channel": slack_channel,
+                    "attachments": [
+                        {
+                            "pretext": notify_data.title,
+                            "color": notify_data.color,
+                            "text": notify_data.message,
+                        }
+                    ],
                 }
-            ],
-        }
+            )
+        return data
 
 
 class Console:

--- a/kot/service.py
+++ b/kot/service.py
@@ -57,7 +57,7 @@ def scrape_kot(params: ScrapeKOTParams) -> str:
         )
         slack_client_params = ScrapeKOTSlackClientParams(
             slack_webhook_url=cfg.scrapekot.slack.webhook_url,
-            slack_channel=cfg.scrapekot.slack.channel,
+            slack_channels=cfg.scrapekot.slack.channels,
             slack_icon_emoji=cfg.scrapekot.slack.icon_emoji,
             slack_username=cfg.scrapekot.slack.username,
             dt_now=datetime.now(),
@@ -99,7 +99,7 @@ def punch_myrecorder(params: MyRecorderParams) -> None:
         is_punched = MyRecorderCrawler(browser).run(crawler_params)
         slack_client_params = MyRecorderSlackClientParams(
             slack_webhook_url=cfg.myrecorder.slack.webhook_url,
-            slack_channel=cfg.myrecorder.slack.channel,
+            slack_channels=cfg.myrecorder.slack.channels,
             slack_icon_emoji=cfg.myrecorder.slack.icon_emoji,
             slack_username=cfg.myrecorder.slack.username,
             command=params.command,

--- a/tasks.py
+++ b/tasks.py
@@ -8,7 +8,8 @@ def build(c):
     """
     c.run(
         """
-        docker compose build
+        echo 'docker compose build'
+        docker compose build -q
     """
     )
 

--- a/tasks.py
+++ b/tasks.py
@@ -13,7 +13,7 @@ def build(c):
     )
 
 
-@task
+@task(build)
 def scrapekot(c):
     """
     Run scrapekot to notify on console
@@ -25,7 +25,7 @@ def scrapekot(c):
     )
 
 
-@task
+@task(build)
 def scrapekot_slack(c):
     """
     Run scrapekot to notify on slack
@@ -37,7 +37,7 @@ def scrapekot_slack(c):
     )
 
 
-@task
+@task(build)
 def myrecorder_start(c):
     """
     Run MyRecorder to start working
@@ -49,7 +49,7 @@ def myrecorder_start(c):
     )
 
 
-@task
+@task(build)
 def myrecorder_end(c):
     """
     Run MyRecorder to end working
@@ -61,7 +61,7 @@ def myrecorder_end(c):
     )
 
 
-@task
+@task(build)
 def myrecorder_start_rest(c):
     """
     Run MyRecorder to start rest
@@ -73,7 +73,7 @@ def myrecorder_start_rest(c):
     )
 
 
-@task
+@task(build)
 def myrecorder_end_rest(c):
     """
     Run MyRecorder to end rest

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -25,13 +25,16 @@ account:
 scrapekot:
   slack:
     webhook_url: scrapekot_url
-    channel: scrapekot_channel
+    channels:
+      - scrapekot_channel
     icon_emoji: scrapekot_emoji
     username: scrapekot_username
 myrecorder:
   slack:
     webhook_url: myrecorder_url
-    channel: myrecorder_channel
+    channels:
+      - myrecorder_channel_1
+      - myrecorder_channel_2
     icon_emoji: myrecorder_emoji
     username: myrecorder_username
 """
@@ -57,7 +60,7 @@ def test_read_env():
             "scrapekot": {
                 "slack": {
                     "webhook_url": "scrapekot_url",
-                    "channel": "scrapekot_channel",
+                    "channels": ["scrapekot_channel"],
                     "icon_emoji": "scrapekot_emoji",
                     "username": "scrapekot_username",
                 },
@@ -65,7 +68,7 @@ def test_read_env():
             "myrecorder": {
                 "slack": {
                     "webhook_url": "myrecorder_url",
-                    "channel": "myrecorder_channel",
+                    "channels": ["myrecorder_channel_1", "myrecorder_channel_2"],
                     "icon_emoji": "myrecorder_emoji",
                     "username": "myrecorder_username",
                 },
@@ -92,7 +95,7 @@ def test_load_config():
             scrapekot=ScrapeKOT(
                 slack=Slack(
                     webhook_url="scrapekot_url",
-                    channel="scrapekot_channel",
+                    channels=["scrapekot_channel"],
                     icon_emoji="scrapekot_emoji",
                     username="scrapekot_username",
                 ),
@@ -100,7 +103,7 @@ def test_load_config():
             myrecorder=MyRecorder(
                 slack=Slack(
                     webhook_url="myrecorder_url",
-                    channel="myrecorder_channel",
+                    channels=["myrecorder_channel_1", "myrecorder_channel_2"],
                     icon_emoji="myrecorder_emoji",
                     username="myrecorder_username",
                 ),
@@ -125,7 +128,7 @@ def test_generate_config():
         "scrapekot": {
             "slack": {
                 "webhook_url": "scrapekot_url",
-                "channel": "scrapekot_channel",
+                "channels": ["scrapekot_channel"],
                 "icon_emoji": "scrapekot_emoji",
                 "username": "scrapekot_username",
             }
@@ -133,7 +136,7 @@ def test_generate_config():
         "myrecorder": {
             "slack": {
                 "webhook_url": "myrecorder_url",
-                "channel": "myrecorder_channel",
+                "channels": ["myrecorder_channel_1", "myrecorder_channel_2"],
                 "icon_emoji": "myrecorder_emoji",
                 "username": "myrecorder_username",
             }
@@ -144,7 +147,7 @@ def test_generate_config():
         scrapekot=ScrapeKOT(
             slack=Slack(
                 webhook_url="scrapekot_url",
-                channel="scrapekot_channel",
+                channels=["scrapekot_channel"],
                 icon_emoji="scrapekot_emoji",
                 username="scrapekot_username",
             ),
@@ -152,7 +155,7 @@ def test_generate_config():
         myrecorder=MyRecorder(
             slack=Slack(
                 webhook_url="myrecorder_url",
-                channel="myrecorder_channel",
+                channels=["myrecorder_channel_1", "myrecorder_channel_2"],
                 icon_emoji="myrecorder_emoji",
                 username="myrecorder_username",
             ),
@@ -190,7 +193,7 @@ def test_read_lambda_env():
         "myrecorder": {
             "slack": {
                 "webhook_url": "myrecorder_url",
-                "channel": "myrecorder_channel",
+                "channels": ["myrecorder_channel"],
                 "icon_emoji": "myrecorder_emoji",
                 "username": "myrecorder_username",
             }
@@ -198,7 +201,7 @@ def test_read_lambda_env():
         "scrapekot": {
             "slack": {
                 "webhook_url": "scrapekot_url",
-                "channel": "scrapekot_channel",
+                "channels": ["scrapekot_channel"],
                 "icon_emoji": "scrapekot_emoji",
                 "username": "scrapekot_username",
             }

--- a/tests/myrecorder/test_notify.py
+++ b/tests/myrecorder/test_notify.py
@@ -34,7 +34,7 @@ def test_SlackClient__build_noitfy_data(mocker):
     params = [
         SlackClientParams(
             slack_webhook_url="myrecorder_url",
-            slack_channel="myrecorder_channel",
+            slack_channels=["myrecorder_channel"],
             slack_icon_emoji="myrecorder_emoji",
             slack_username="myrecorder_username",
             command="start",
@@ -48,7 +48,7 @@ def test_SlackClient__build_noitfy_data(mocker):
     expected = [
         NotifyData(
             slack_webhook_url="myrecorder_url",
-            slack_channel="myrecorder_channel",
+            slack_channels=["myrecorder_channel"],
             slack_icon_emoji="myrecorder_emoji",
             slack_username="myrecorder_username",
             message=":shukkin:",
@@ -58,7 +58,7 @@ def test_SlackClient__build_noitfy_data(mocker):
         None,
         NotifyData(
             slack_webhook_url="myrecorder_url",
-            slack_channel="myrecorder_channel",
+            slack_channels=["myrecorder_channel"],
             slack_icon_emoji="myrecorder_emoji",
             slack_username="myrecorder_username",
             message=":shukkin:",
@@ -92,7 +92,7 @@ def test_SlackClient__post_slack(mocker):
     mocker.patch("requests.post", side_effect=mock_func_requests_post)
     notify_data = NotifyData(
         slack_webhook_url="myrecorder_url",
-        slack_channel="myrecorder_channel",
+        slack_channels=["myrecorder_channel"],
         slack_icon_emoji="myrecorder_emoji",
         slack_username="myrecorder_username",
         message="test_message",
@@ -111,7 +111,7 @@ def test_SlackClient__slack_url():
 
     notify_data = NotifyData(
         slack_webhook_url="myrecorder_url",
-        slack_channel="myrecorder_channel",
+        slack_channels=["myrecorder_channel"],
         slack_icon_emoji="myrecorder_emoji",
         slack_username="myrecorder_username",
         message="test_message",
@@ -132,17 +132,19 @@ def test_SlackClient__slack_data():
 
     notify_data = NotifyData(
         slack_webhook_url="myrecorder_url",
-        slack_channel="myrecorder_channel",
+        slack_channels=["myrecorder_channel"],
         slack_icon_emoji="myrecorder_emoji",
         slack_username="myrecorder_username",
         message="test_message",
     )
-    expected = {
-        "username": "myrecorder_username",
-        "icon_emoji": "myrecorder_emoji",
-        "channel": "myrecorder_channel",
-        "text": "test_message",
-    }
+    expected = [
+        {
+            "username": "myrecorder_username",
+            "icon_emoji": "myrecorder_emoji",
+            "channel": "myrecorder_channel",
+            "text": "test_message",
+        }
+    ]
     fixtures = [Fixture("", notify_data, expected)]
     for fixture in fixtures:
         assert api._slack_data(fixture.notify_data) == fixture.expected, fixture.desc

--- a/tests/scrapekot/test_notify.py
+++ b/tests/scrapekot/test_notify.py
@@ -32,7 +32,7 @@ def test_SlackClient__build_noitfy_data(mocker):
 
     params = SlackClientParams(
         slack_webhook_url="scrapekot_url",
-        slack_channel="scrapekot_channel",
+        slack_channels=["scrapekot_channel"],
         slack_icon_emoji="scrapekot_emoji",
         slack_username="scrapekot_username",
         dt_now=datetime(2022, 3, 17, 0, 7, 37, 819883),
@@ -54,7 +54,7 @@ def test_SlackClient__build_noitfy_data(mocker):
     color = api._get_color(data.saving_time)
     expected = NotifyData(
         slack_webhook_url="scrapekot_url",
-        slack_channel="scrapekot_channel",
+        slack_channels=["scrapekot_channel"],
         slack_icon_emoji="scrapekot_emoji",
         slack_username="scrapekot_username",
         message=message,
@@ -92,7 +92,7 @@ def test_SlackClient__post_slack(mocker):
     mocker.patch("requests.post", side_effect=mock_func_requests_post)
     notify_data = NotifyData(
         slack_webhook_url="scrapekot_url",
-        slack_channel="scrapekot_channel",
+        slack_channels=["scrapekot_channel"],
         slack_icon_emoji="scrapekot_emoji",
         slack_username="scrapekot_username",
         message="test_message",
@@ -162,7 +162,7 @@ def test_SlackClient__slack_url():
 
     notify_data = NotifyData(
         slack_webhook_url="scrapekot_url",
-        slack_channel="scrapekot_channel",
+        slack_channels=["scrapekot_channel"],
         slack_icon_emoji="scrapekot_emoji",
         slack_username="scrapekot_username",
         message="test_message",
@@ -183,25 +183,27 @@ def test_SlackClient__slack_data():
 
     notify_data = NotifyData(
         slack_webhook_url="scrapekot_url",
-        slack_channel="scrapekot_channel",
+        slack_channels=["scrapekot_channel"],
         slack_icon_emoji="scrapekot_emoji",
         slack_username="scrapekot_username",
         message="test_message",
         title="test_title",
         color="green",
     )
-    expected = {
-        "username": "scrapekot_username",
-        "icon_emoji": "scrapekot_emoji",
-        "channel": "scrapekot_channel",
-        "attachments": [
-            {
-                "pretext": "test_title",
-                "color": "green",
-                "text": "test_message",
-            }
-        ],
-    }
+    expected = [
+        {
+            "username": "scrapekot_username",
+            "icon_emoji": "scrapekot_emoji",
+            "channel": "scrapekot_channel",
+            "attachments": [
+                {
+                    "pretext": "test_title",
+                    "color": "green",
+                    "text": "test_message",
+                }
+            ],
+        }
+    ]
     fixtures = [Fixture("", notify_data, expected)]
     for fixture in fixtures:
         assert api._slack_data(fixture.notify_data) == fixture.expected, fixture.desc


### PR DESCRIPTION
複数のチャンネルに通知できるようにした

⚠️ config.yaml の形式が変わった（フィールド名が channel -> channels に、データ型が str -> list[str] になった）

before
```
    account:
        id: id
        password: passaword
    scrapekot:
        slack:
            webhook_url: url
            channel: channel
            icon_emoji: icon
            username: username
    myrecorder:
        slack:
            webhook_url: url
            channel: channel
            icon_emoji: icon
            username: username
```

after
```
    account:
        id: id
        password: passaword
    scrapekot:
        slack:
            webhook_url: url
            channels:
              - channel_a
            icon_emoji: icon
            username: username
    myrecorder:
        slack:
            webhook_url: url
            channels:
              - channel_a
              - channel_b
            icon_emoji: icon
            username: username
```